### PR TITLE
Change reload cell modifire

### DIFF
--- a/FSCalendar/FSCalendar.h
+++ b/FSCalendar/FSCalendar.h
@@ -408,6 +408,11 @@ IB_DESIGNABLE
 - (void)reloadData;
 
 /**
+Reload data of the calendar cell.
+*/
+- (void)reloadDataForCell:(FSCalendarCell *)cell atIndexPath:(NSIndexPath *)indexPath;
+
+/**
  Change the scope of the calendar. Make sure `-calendar:boundingRectWillChange:animated` is correctly adopted.
  
  @param scope The target scope to change.

--- a/FSCalendar/FSCalendar.m
+++ b/FSCalendar/FSCalendar.m
@@ -110,8 +110,6 @@ typedef NS_ENUM(NSUInteger, FSCalendarOrientation) {
 - (void)selectCounterpartDate:(NSDate *)date;
 - (void)deselectCounterpartDate:(NSDate *)date;
 
-- (void)reloadDataForCell:(FSCalendarCell *)cell atIndexPath:(NSIndexPath *)indexPath;
-
 - (void)adjustMonthPosition;
 - (BOOL)requestBoundingDatesIfNecessary;
 - (void)executePendingOperationsIfNeeded;


### PR DESCRIPTION
Вынесла недостающий метод 
 - (void)reloadDataForCell:(FSCalendarCell *)cell atIndexPath:(NSIndexPath *)indexPath;
для переопределения методов UICollectionViewDataSource у календаря